### PR TITLE
Fix port config issue on node2

### DIFF
--- a/canopy_data/node2/config.json
+++ b/canopy_data/node2/config.json
@@ -23,7 +23,7 @@
   "dbName": "canopy",
   "inMemory": false,
   "networkID": 1,
-  "listenAddress": "0.0.0.0:9001",
+  "listenAddress": "0.0.0.0:9002",
   "externalAddress": "tcp://node2.localhost",
   "maxInbound": 21,
   "maxOutbound": 7,


### PR DESCRIPTION
Should be 9002 instead of 9001 on node2