### PR TITLE
fix: spelling on deployment config jsons side

### DIFF
--- a/canopy_data/node1/config.json
+++ b/canopy_data/node1/config.json
@@ -27,7 +27,7 @@
   "externalAddress": "tcp://node1.localhost",
   "maxInbound": 21,
   "maxOutbound": 7,
-  "trutedPeersIDs": null,
+  "trustedPeerIDs": null,
   "dialPeers": [
     "90703d453dfa70af3c85f3605e6cc8222d01d68d439ee5a9ade10be631572b330e1793206c8d417d9693be1d5af417fe@tcp://cnpy.network",
     "b338f09135994130bee5da939513241b5d01ba5e73c409ed5ecea597b86a8b9c05fd27fb5e47a7296350fbae6262a484@tcp://cnpynetwork.com"

--- a/canopy_data/node2/config.json
+++ b/canopy_data/node2/config.json
@@ -27,7 +27,7 @@
   "externalAddress": "tcp://node2.localhost",
   "maxInbound": 21,
   "maxOutbound": 7,
-  "trutedPeersIDs": null,
+  "trustedPeerIDs": null,
   "dialPeers": [
     "8ad02e9b05e418f198e89179685a48b227f1c2bc266d4db002f24f8155c5119cbb9387146319b5dc4a260184f20d5d4f@tcp://cnpy.xyz"
   ],


### PR DESCRIPTION
Fix spelling of trustedPeerIDs

https://github.com/canopy-network/canopy/pull/226 this PR should be released before merging this PR