### PR TITLE
chore: change auto update dir

### DIFF
--- a/docker_image/Dockerfile
+++ b/docker_image/Dockerfile
@@ -33,7 +33,7 @@ RUN make build/wallet
 RUN make build/explorer
 
 # Builds auto-update CLI
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o bin ./auto-update/.
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o bin ./cmd/auto-update/.
 
 # Only build if the file at ${BIN_PATH} doesn't already exist
 RUN if [ ! -f "${BIN_PATH}" ]; then \


### PR DESCRIPTION
Change dir of auto update for new release

IMPORTANT NOTICE:
Do not merge until changes in https://github.com/canopy-network/canopy/pull/235 are merged

Steps for next release:

- Merge canopy PR
- Wait to have enough changes for a release
- Merge deployments PR
- Right the way trigger the release from canopy repo