### PR TITLE
Fix/host to path

### DIFF
--- a/docker_image/Dockerfile
+++ b/docker_image/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:18-alpine AS builder 
 
-ARG WALLET_DIR
-ARG EXPLORER_DIR 
+ARG EXPLORER_BASE_PATH
+ARG WALLET_BASE_PATH 
 ARG BRANCH='latest'
 ARG CLI_DIR
 ARG BUILD_PATH=cmd/cli
@@ -26,6 +26,9 @@ RUN echo "Building from BRANCH=${BRANCH}" && \
 # copy golang 
 COPY --from=golang:1.23.9-alpine  /usr/local/go/ /usr/local/go/
 ENV PATH="/usr/local/go/bin:${PATH}"
+ENV EXPLORER_BASE_PATH=${EXPLORER_BASE_PATH}
+ENV WALLET_BASE_PATH=${WALLET_BASE_PATH}
+
 RUN go version
 # Builds 
 RUN apk update && apk add --no-cache make bash nodejs npm 

--- a/monitoring-stack/README.md
+++ b/monitoring-stack/README.md
@@ -169,9 +169,9 @@ It will also properly configure to expose canopy nodes explorer, rpc and wallet 
 
 Node1 config.json
 ```
-  "rpcURL": "https://rpc.node1.<YOUR_DOMAIN>:50002",
+  "rpcURL": "https://node1.<YOUR_DOMAIN>/rpc",
 
-  "adminRPCUrl": "https://adminrpc.node1.<YOUR_DOMAIN>:50003",
+  "adminRPCUrl": "https://node1.<YOUR_DOMAIN>/adminrpc",
 
   "externalAddress": "tcp://node1.<YOUR_DOMAIN>",
 ```
@@ -179,9 +179,9 @@ Node1 config.json
 Node2 config.json
 
 ```
-  "rpcURL": "https://rpc.node2.<YOUR_DOMAIN>:40002",
+  "rpcURL": "https://node2.<YOUR_DOMAIN>/rpc",
   
-  "adminRPCUrl": "https://admin.node2.<YOUR_DOMAIN>:40003",
+  "adminRPCUrl": "https://node2.<YOUR_DOMAIN>/adminrpc",
 
   "externalAddress": "tcp://node2.<YOUR_DOMAIN>",
 ```

--- a/monitoring-stack/docker-compose.yaml
+++ b/monitoring-stack/docker-compose.yaml
@@ -21,8 +21,8 @@ services:
       dockerfile: ./Dockerfile
       network: host
       args:
-        EXPLORER_BASE_PATH: '/'
-        WALLET_BASE_PATH: '/'
+        EXPLORER_BASE_PATH: '/explorer'
+        WALLET_BASE_PATH: '/wallet'
         BUILD_PATH: cmd/cli
         BIN_PATH: $BIN_PATH
         BRANCH: latest

--- a/monitoring-stack/loadbalancer/services/local.yaml
+++ b/monitoring-stack/loadbalancer/services/local.yaml
@@ -50,7 +50,7 @@ http:
       - web
     canopy-monitoring-local:
       rule: Host(`monitoring.localhost`)
-      service: canopy-monitoring 
+      service: canopy-monitoring-local
       priority: 1
       entryPoints:
       - web

--- a/monitoring-stack/loadbalancer/services/middleware.yaml
+++ b/monitoring-stack/loadbalancer/services/middleware.yaml
@@ -25,6 +25,26 @@ http:
         users:
           - "canopy:$apr1$GnHnOP0b$zWcOv5kosOuUAuvrlu72C0"
 
+    strip-wallet-prefix:
+      stripPrefix:
+        prefixes:
+          - "/wallet"
+
+    strip-explorer-prefix:
+      stripPrefix:
+        prefixes:
+          - "/explorer"
+
+    strip-rpc-prefix:
+      stripPrefix:
+        prefixes:
+          - "/rpc"
+
+    strip-adminrpc-prefix:
+      stripPrefix:
+        prefixes:
+          - "/adminrpc"
+
     websocket-headers:
       headers:
         customRequestHeaders:

--- a/monitoring-stack/loadbalancer/services/prod.yaml
+++ b/monitoring-stack/loadbalancer/services/prod.yaml
@@ -1,143 +1,190 @@
+# traefik-dynamic.yaml
 http:
   routers:
     canopy-monitoring:
-      rule: Host(`monitoring.{{ env "DOMAIN" }}`) 
-      service: canopy-monitoring 
+      rule: Host(`monitoring.{{ env "DOMAIN" }}`)
+      service: canopy-monitoring
       priority: 1
       entryPoints:
-      - web
-      - websecure 
+        - web
+        - websecure
       middlewares:
-      - https-redirect
+        - https-redirect
       tls:
         certResolver: https-resolver
-    canopy-wallet:
-      rule:   Host(`wallet.node1.{{ env "DOMAIN" }}`)
+
+    canopy-node1-wallet:
+      rule: Host(`node1.{{ env "DOMAIN" }}`) && PathPrefix(`/wallet`)
       service: canopy-wallet
       priority: 1
       entryPoints:
-      - web
-      - websecure 
+        - web
+        - websecure
       middlewares:
-      - https-redirect
-      - basic-auth
+        - https-redirect
+        - basic-auth
+        - strip-wallet-prefix
       tls:
         certResolver: https-resolver
-    canopy-explorer:
-      rule:   Host(`explorer.node1.{{ env "DOMAIN" }}`) 
+
+    canopy-node1-explorer:
+      rule: Host(`node1.{{ env "DOMAIN" }}`) && PathPrefix(`/explorer`)
       service: canopy-explorer
       priority: 1
       entryPoints:
-      - web
-      - websecure
+        - web
+        - websecure
+      middlewares:
+        - https-redirect
+        - strip-explorer-prefix
       tls:
         certResolver: https-resolver
-    canopy-rpc:
-      rule:   Host(`rpc.node1.{{ env "DOMAIN" }}`) 
+
+
+    canopy-node1-rpc:
+      rule: Host(`node1.{{ env "DOMAIN" }}`) && PathPrefix(`/rpc`)
       service: canopy-rpc
       priority: 1
       entryPoints:
-      - web
-      - websecure
+        - web
+        - websecure
+      middlewares:
+        - https-redirect
+        - strip-rpc-prefix
       tls:
         certResolver: https-resolver
-    canopy-admin-rpc:
-      rule: Host(`adminrpc.node1.{{ env "DOMAIN" }}`)
+
+    canopy-node1-admin-rpc:
+      rule: Host(`node1.{{ env "DOMAIN" }}`) && PathPrefix(`/adminrpc`)
       service: canopy-admin-rpc
       priority: 1
       entryPoints:
-      - web
-      - websecure
+        - web
+        - websecure
       middlewares:
-      - https-redirect
-      - basic-auth
+        - https-redirect
+        - basic-auth
+        - strip-adminrpc-prefix
       tls:
         certResolver: https-resolver
-    canopy-wallet2:
-      rule: Host(`wallet.node2.{{ env "DOMAIN" }}`) 
+
+    canopy-node2-wallet:
+      rule: Host(`node2.{{ env "DOMAIN" }}`) && PathPrefix(`/wallet`)
       service: canopy-wallet2
       priority: 1
       entryPoints:
-      - web
-      - websecure
+        - web
+        - websecure
       middlewares:
-      - https-redirect
-      - basic-auth
+        - https-redirect
+        - basic-auth
+        - strip-wallet-prefix
       tls:
         certResolver: https-resolver
-    canopy-explorer2:
-      rule: Host(`explorer.node2.{{ env "DOMAIN" }}`)
+
+    canopy-node2-explorer:
+      rule: Host(`node2.{{ env "DOMAIN" }}`) && PathPrefix(`/explorer`)
       service: canopy-explorer2
       priority: 1
       entryPoints:
-      - web
-      - websecure
+        - web
+        - websecure
+      middlewares:
+        - https-redirect
+        - strip-explorer-prefix
       tls:
         certResolver: https-resolver
-    canopy-rpc2:
-      rule: Host(`rpc.node2.{{ env "DOMAIN" }}`)
+
+    canopy-node2-rpc:
+      rule: Host(`node2.{{ env "DOMAIN" }}`) && PathPrefix(`/rpc`)
       service: canopy-rpc2
       priority: 1
       entryPoints:
-      - web
-      - websecure
+        - web
+        - websecure
+      middlewares:
+        - https-redirect
+        - strip-rpc-prefix
       tls:
         certResolver: https-resolver
-    canopy-admin-rpc2:
-      rule: Host(`adminrpc.node2.{{ env "DOMAIN" }}`)
+
+    canopy-node2-admin-rpc:
+      rule: Host(`node2.{{ env "DOMAIN" }}`) && PathPrefix(`/adminrpc`)
       service: canopy-admin-rpc2
       priority: 1
       entryPoints:
-      - web
-      - websecure
+        - web
+        - websecure
       middlewares:
-      - https-redirect
-      - basic-auth
+        - https-redirect
+        - basic-auth
+        - strip-adminrpc-prefix
       tls:
         certResolver: https-resolver
+
   services:
     canopy-wallet:
       loadBalancer:
-        passHostHeader: false 
+        passHostHeader: false
         servers:
-          - url: http://node1:50000
+          - url: http://node1:50000/
+
+    canopy-wallet-static:
+      loadBalancer:
+        passHostHeader: false
+        servers:
+          - url: http://node1:50000/_next/
+
     canopy-explorer:
       loadBalancer:
-        passHostHeader: false 
+        passHostHeader: false
         servers:
           - url: http://node1:50001
+
+    canopy-explorer-static:
+      loadBalancer:
+        passHostHeader: false
+        servers:
+          - url: http://node1:50001/_next/
+
     canopy-rpc:
       loadBalancer:
-        passHostHeader: true 
+        passHostHeader: true
         servers:
           - url: http://node1:50002/
+
     canopy-admin-rpc:
       loadBalancer:
-        passHostHeader: true 
+        passHostHeader: true
         servers:
           - url: http://node1:50003/
+
     canopy-wallet2:
       loadBalancer:
         passHostHeader: false
         servers:
           - url: http://node2:40000
+
     canopy-explorer2:
       loadBalancer:
         passHostHeader: false
         servers:
           - url: http://node2:40001
+
     canopy-rpc2:
       loadBalancer:
-        passHostHeader: true 
+        passHostHeader: true
         servers:
           - url: http://node2:40002/
+
     canopy-admin-rpc2:
       loadBalancer:
-        passHostHeader: true 
+        passHostHeader: true
         servers:
           - url: http://node2:40003/
+
     canopy-monitoring:
       loadBalancer:
-        passHostHeader: true 
+        passHostHeader: true
         servers:
           - url: http://grafana:3000/

--- a/setup.sh
+++ b/setup.sh
@@ -87,14 +87,14 @@ if [[ -n "$DOMAIN" ]]; then
 
   # Replace RPC and Admin RPC URLs for node1
   sed -i -E \
-    -e "s|\"rpcURL\": *\"http://localhost:50002\"|\"rpcURL\": \"https://rpc.node1.$DOMAIN\"|" \
-    -e "s|\"adminRPCUrl\": *\"http://localhost:50003\"|\"adminRPCUrl\": \"https://adminrpc.node1.$DOMAIN\"|" \
+    -e "s|\"rpcURL\": *\"http://localhost:50002\"|\"rpcURL\": \"https://node1.$DOMAIN/rpc\"|" \
+    -e "s|\"adminRPCUrl\": *\"http://localhost:50003\"|\"adminRPCUrl\": \"https://node1.$DOMAIN/adminrpc\"|" \
     "$NODE1_CONFIG"
 
   # Replace RPC and Admin RPC URLs for node2
   sed -i -E \
-    -e "s|\"rpcURL\": *\"http://localhost:40002\"|\"rpcURL\": \"https://rpc.node2.$DOMAIN\"|" \
-    -e "s|\"adminRPCUrl\": *\"http://localhost:40003\"|\"adminRPCUrl\": \"https://adminrpc.node2.$DOMAIN\"|" \
+    -e "s|\"rpcURL\": *\"http://localhost:40002\"|\"rpcURL\": \"https://node2.$DOMAIN/rpc\"|" \
+    -e "s|\"adminRPCUrl\": *\"http://localhost:40003\"|\"adminRPCUrl\": \"https://node2.$DOMAIN/adminrpc\"|" \
     "$NODE2_CONFIG"
 fi
 


### PR DESCRIPTION
Changes Loadbalancer approachs from host to path as follows:

wallet.node1.{DOMAIN} -> node1.{DOMAIN}/wallet
explorer.node1.{DOMAIN} -> node1.{DOMAIN}/explorer
rpc.node1.{DOMAIN} -> node1.{DOMAIN}/rpc
adminrpc.node1.{DOMAIN} -> node1.{DOMAIN}/adminrpc

- For this change to apply on your production setup you need to:

- re-updating the password on the loadbalancer middleware.yaml since the updates changes this file and will overwrite the user basic auth pass
- rewrite the config.json for node1 and node2 using this nomenclature (included as well in the monitoring-stack/readme.md)

"adminRPCUrl": "https://node2.<YOUR_DOMAIN>/adminrpc",
  "rpcURL": "https://node1.<YOUR_DOMAIN>/rpc",

- Finally build the image using the make file or just `docker-compose build --no-cache` before running on monitoring-stack since we need the canopy binary built with the following variables:

```
        EXPLORER_BASE_PATH: '/explorer'
        WALLET_BASE_PATH: '/wallet'
```
