### PR TITLE
fix(setup): remove shared validator key copy — prevents double-signing slash

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,8 +3,15 @@ echo "setting up the validator key"
 docker pull canopynetwork/canopy && \
 docker run --user root -it -p 50000:50000 -p 50001:50001 -p 50002:50002 -p 50003:50003 -p 9001:9001 --name canopy-config  --volume ${PWD}/canopy_data/node1/:/root/.canopy/ canopynetwork/canopy && \
 docker stop canopy-config && docker rm canopy-config && \
-cp canopy_data/node1/validator_key.json canopy_data/node2/ && \
-cp canopy_data/node1/keystore.json canopy_data/node2/
+# IMPORTANT: Do NOT copy node1 validator_key.json or keystore.json to node2.
+# Each validator must have its own unique key. Sharing a validator key between
+# nodes causes both to sign the same consensus messages, which is treated as
+# equivocation (double-signing) and results in the validator being slashed.
+# node2 should either generate a fresh key via "canopy init" or be given a
+# separate pre-existing key before starting.
+echo "WARNING: node2 requires its own validator_key.json and keystore.json.";
+echo "Please run: docker run --rm -v ${PWD}/canopy_data/node2:/root/.canopy canopynetwork/canopy init";
+echo "to generate a fresh key pair for node2 before starting the stack."
 
 # ask user for setup type
 echo "Please select setup type:"


### PR DESCRIPTION
## Bug

`setup.sh` copies node1's `validator_key.json` **and** `keystore.json` directly into `canopy_data/node2/`:

```bash
cp canopy_data/node1/validator_key.json canopy_data/node2/
cp canopy_data/node1/keystore.json canopy_data/node2/
```

This makes both nodes share an identical validator key. In consensus, both nodes will sign the same block height with the same key from different network identities — this is **equivocation (double-signing)**.

**Impact:** The protocol treats double-signing as a Byzantine fault. The shared validator is slashed and permanently removed from the active validator set. Any operator who follows the README and runs `setup.sh` as documented has their validator immediately at risk.

## Fix

Remove the copy commands. Replace them with a warning that clearly tells the operator to initialise a separate key for node2 using `canopy init`, and provide the exact command to do so.

Each node in a multi-validator deployment **must** hold a unique `validator_key.json`.