### PR TITLE
fix(setup): add -r to read -s PASSWORD to prevent backslash corruption

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -111,7 +111,7 @@ echo "Enter username:"
 read USERNAME
 
 echo "Enter password:"
-read -s PASSWORD
+read -r -s PASSWORD
 echo
 
 if ! command -v htpasswd &> /dev/null; then


### PR DESCRIPTION
## Bug

`setup.sh` reads the monitoring-stack admin password with:

```bash
read -s PASSWORD
```

In bash, `read` **without `-r`** treats backslashes as escape characters. Any operator password containing a backslash (e.g. `P@ss\\word1`, a common pattern in auto-generated strong passwords) is silently mangled before being passed to `htpasswd`.

**Impact:** The hash written to `middleware.yaml` does not correspond to the password the operator typed. The operator is locked out of the monitoring dashboard immediately after setup, with no error message — the failure only appears when attempting to log in.

## Fix

Add `-r` to the `read` invocation:

```bash
# Before
read -s PASSWORD

# After
read -r -s PASSWORD
```

The `-r` flag disables backslash escaping so the raw bytes of the password are used, matching the hash generated by `htpasswd`.